### PR TITLE
Fixing the version vars not being used at one line

### DIFF
--- a/OpenNameSearch-Ubuntu16.sh
+++ b/OpenNameSearch-Ubuntu16.sh
@@ -70,7 +70,7 @@ function install_prerequisites(){
     sudo apt-get install -y build-essential cmake g++ libboost-dev libboost-system-dev \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev libxml2-dev\
         libbz2-dev libpq-dev libgeos-dev libgeos++-dev libproj-dev \
-        postgresql-server-dev-9.5 postgresql-9.5-postgis-2.2 postgresql-contrib-9.5 \
+        postgresql-server-dev-${PG_VER} postgresql-${PG_VER}-postgis-${PGIS_VER} postgresql-contrib-${PG_VER} \
         apache2 php php-pgsql libapache2-mod-php php-pear php-db \
         php-intl git python-pip python-pyosmium osmosis libboost-python-dev
 }


### PR DESCRIPTION
This fixes ${PG_VER} and ${PGIS_VER} not being used at one point.